### PR TITLE
Fix some issues that prevented building

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ Additionally, you must have [Graphviz](https://graphviz.org/download/) installed
 
 Linoone uses `pycparser` to parse the project's C files. `pycparser` has a couple issues with parsing the vanilla pokeemerald source code. You'll have to make a couple manual modifications to pokeemerald first:
 
-In `include/global.h`, make the following modifications:
-1. Stub out `__attribute__` at the top of the file.
+In `include/global.h`, stub out `__attribute__` at the top of the file.
 ```diff
 @@ -1,6 +1,8 @@
  #ifndef GUARD_GLOBAL_H
@@ -28,20 +27,8 @@ In `include/global.h`, make the following modifications:
  #include "config.h" // we need to define config before gba headers as print stuff needs the functions nulled before defines.
 @@ -107,7 +109,7 @@
 ```
-2. Fix the `TEST_BUTTON` macro.
-```diff
-@@ -107,7 +109,7 @@
- #define T2_READ_PTR(ptr) (void*) T2_READ_32(ptr)
 
- // Macros for checking the joypad
--#define TEST_BUTTON(field, button) ({(field) & (button);})
-+#define TEST_BUTTON(field, button) ((field) & (button))
- #define JOY_NEW(button) TEST_BUTTON(gMain.newKeys,  button)
- #define JOY_HELD(button)  TEST_BUTTON(gMain.heldKeys, button)
- #define JOY_HELD_RAW(button) TEST_BUTTON(gMain.heldKeysRaw, button)
-```
-
-Finally, there is a bug in `pycparser` which makes it choke on various unicode characters in the decomp files. You need to manually apply this fix to your local installation of `pycparser`: https://github.com/eliben/pycparser/issues/415
+There is also a bug in `pycparser` which makes it choke on various unicode characters in the decomp files. You need to manually apply this fix to your local installation of `pycparser`: https://github.com/eliben/pycparser/issues/415
 
 That's all--you should now be ready to run Linoone. See the Usage section below.
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ pip install -r requirements.txt
 
 Additionally, you must have [Graphviz](https://graphviz.org/download/) installed and available on your path.
 
-Linoone uses `pycparser` to parse the project's C files. `pycparser` has a couple issues with parsing the vanilla pokeemerald source code. You'll have to make a couple manual modifications to pokeemerald first:
+Linoone uses `pycparser` to parse the project's C files. `pycparser` has a couple issues with parsing the vanilla pokeemerald source code.
 
-In `include/global.h`, stub out `__attribute__` at the top of the file.
+In your pokeemerald repo, in `include/global.h`, stub out `__attribute__` at the top of the file.
 ```diff
 @@ -1,6 +1,8 @@
  #ifndef GUARD_GLOBAL_H

--- a/generators/mon_summaries.py
+++ b/generators/mon_summaries.py
@@ -34,15 +34,16 @@ class MonSummariesGenerator(BaseGenerator):
         Generates all of the Pokémon summary pages into the distribution directory.
         """
         for national_num in self.core_data["national_to_species"]:
-            self.render_template(
-                env,
-                "mon_summary.html",
-                "pokedex/%s.html" % national_num,
-                extra_data={
-                    "national_num": national_num,
-                    "species": self.core_data["national_to_species"][national_num],
-                }
-            )
+            if national_num in self.core_data["mon_dex_entries"]:
+                self.render_template(
+                    env,
+                    "mon_summary.html",
+                    "pokedex/%s.html" % national_num,
+                    extra_data={
+                        "national_num": national_num,
+                        "species": self.core_data["national_to_species"][national_num],
+                    }
+                )
 
 
     def create_evolution_sets(self):

--- a/setup/core_data.py
+++ b/setup/core_data.py
@@ -472,6 +472,8 @@ def parse_mon_gfx(config, pic_table_name, pic_table_file, pic_def_file):
     pics_filepath = os.path.join(config["project_dir"], pic_def_file)
     pics_ast = parse_ast_from_file(pics_filepath, config["project_dir"])
 
+    # TODO: Handle Castform's unique gfx filenames
+
     result = {}
     for item in pics.init.exprs:
         if type(item.name[0]) == Constant:

--- a/setup/parse_code.py
+++ b/setup/parse_code.py
@@ -25,9 +25,8 @@ def parse_ast_from_file(filepath, project_path):
         return ast_cache[filepath]
 
     # TODO: There are some issues with the decomp code and pycparser.
-    #       Had to make these modifications to decomp source code:
+    #       Had to make this modifications to decomp source code:
     #       1. In global.h, #define __attribute__(x)
-    #       2. In global.h, #define TEST_BUTTON(field, button) ((field) & (button))
     ast = parse_file(filepath, use_cpp=True, cpp_args=[
         r'-I%s' % os.path.join(project_path, "tools/agbcc/include"),
         r'-I%s' % os.path.join(project_path, "tools/agbcc"),

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -7,9 +7,9 @@
   {% set species = national_to_species[national_num] %}
   {% set type1 = mon_base_stats[species].type1 %}
   {% set type2 = mon_base_stats[species].type2 %}
-  {% set mon_url = make_url('pokedex/' + national_num + '.html') %}
-  <td>{{ national_num }}</td>
-  <td><a href="{{ mon_url }}"><img src="{{ make_url('images/pokemon/' + national_num + '_icon.png') }}"></a></td>
+  {% set mon_url = make_url('pokedex/' + national_num|string + '.html') %}
+  <td>{{ national_num|string }}</td>
+  <td><a href="{{ mon_url }}"><img src="{{ make_url('images/pokemon/' + national_num|string + '_icon.png') }}"></a></td>
   <td><a href="{{ mon_url }}">{{ mon_species_names[species] }}</a></td>
   <td>
     <a href="{{ make_url('types/' + type1 + '.html') }}"><img src="{{ make_url('images/types/' + type1 + '.png') }}"></a>

--- a/templates/mon_summary.html
+++ b/templates/mon_summary.html
@@ -5,14 +5,14 @@
 {% block title %}{{ mon_species_names[species] }}{% endblock %}
 
 {% block content %}
-<h1>#{{ national_num }} - {{ mon_species_names[species] }}</h1>
+<h1>#{{ national_num|string }} - {{ mon_species_names[species] }}</h1>
 
-<img src="{{ make_url('images/pokemon/' + national_num + '_front.png') }}">
-<img src="{{ make_url('images/pokemon/' + national_num + '_back.png') }}">
-<img src="{{ make_url('images/pokemon/' + national_num + '_icon.png') }}">
+<img src="{{ make_url('images/pokemon/' + national_num|string + '_front.png') }}">
+<img src="{{ make_url('images/pokemon/' + national_num|string + '_back.png') }}">
+<img src="{{ make_url('images/pokemon/' + national_num|string + '_icon.png') }}">
 <br>
-<img src="{{ make_url('images/pokemon/' + national_num + '_front_shiny.png') }}">
-<img src="{{ make_url('images/pokemon/' + national_num + '_back_shiny.png') }}">
+<img src="{{ make_url('images/pokemon/' + national_num|string + '_front_shiny.png') }}">
+<img src="{{ make_url('images/pokemon/' + national_num|string + '_back_shiny.png') }}">
 <p><em>{{ mon_dex_entries[national_num].description.replace("\\n", " ") }}</em></p>
 
 <table>


### PR DESCRIPTION
It seems like the biggest change upstream that made Linoone fail to generate on a clean copy of pokeemerald was the movement of the NATIONAL_DEX_ defines into enums in a new file, which this PR naively addresses with a very basic, almost certainly broken enum parser.

There were also some issues with jinja2 expecting variables to be explicitly cast to strings in the templates, and the mon summary generator needs to only create files for species that have dex entries (i.e. ignore the old Unown slots).

EDIT: The TEST_BUTTON macro has also been fixed upstream so isn't needed to be listed in the README instructions anymore.